### PR TITLE
fix: workaround for systemClockOffset to work

### DIFF
--- a/packages/utils/src/EventStreamPayloadHandler.js
+++ b/packages/utils/src/EventStreamPayloadHandler.js
@@ -1,0 +1,40 @@
+import { EventStreamCodec } from "@smithy/eventstream-codec";
+import { getEventSigningTransformStream } from "./get-event-signing-stream.js";
+export class EventStreamPayloadHandler {
+  constructor(options) {
+    this.messageSigner = options.messageSigner;
+    this.eventStreamCodec = new EventStreamCodec(
+      options.utf8Encoder,
+      options.utf8Decoder
+    );
+    this.systemClockOffset = options.systemClockOffset;
+  }
+  async handle(next, args, context = {}) {
+    const request = args.request;
+    const { body: payload, headers, query } = request;
+    if (!(payload instanceof ReadableStream)) {
+      throw new Error("Eventstream payload must be a ReadableStream.");
+    }
+    const placeHolderStream = new TransformStream();
+    request.body = placeHolderStream.readable;
+    let result;
+    try {
+      result = await next(args);
+    } catch (e) {
+      request.body.cancel();
+      throw e;
+    }
+    const match = (headers["authorization"] || "").match(/Signature=([\w]+)$/);
+    const priorSignature =
+      (match || [])[1] || (query && query["X-Amz-Signature"]) || "";
+    const signingStream = getEventSigningTransformStream(
+      priorSignature,
+      await this.messageSigner(),
+      this.eventStreamCodec,
+      this.systemClockOffset
+    );
+    const signedPayload = payload.pipeThrough(signingStream);
+    signedPayload.pipeThrough(placeHolderStream);
+    return result;
+  }
+}

--- a/packages/utils/src/get-event-signing-stream.js
+++ b/packages/utils/src/get-event-signing-stream.js
@@ -1,0 +1,47 @@
+import { fromHex } from "@smithy/util-hex-encoding";
+export const getEventSigningTransformStream = (
+  initialSignature,
+  messageSigner,
+  eventStreamCodec,
+  systemClockOffset
+) => {
+  let priorSignature = initialSignature;
+  const transformer = {
+    start() {},
+    async transform(chunk, controller) {
+      try {
+        const skewCorrectedDate = new Date(Date.now() + systemClockOffset);
+        const dateHeader = {
+          ":date": { type: "timestamp", value: skewCorrectedDate },
+        };
+        const signedMessage = await messageSigner.sign(
+          {
+            message: {
+              body: chunk,
+              headers: dateHeader,
+            },
+            priorSignature: priorSignature,
+          },
+          {
+            signingDate: skewCorrectedDate,
+          }
+        );
+        priorSignature = signedMessage.signature;
+        const serializedSigned = eventStreamCodec.encode({
+          headers: {
+            ...dateHeader,
+            ":chunk-signature": {
+              type: "binary",
+              value: fromHex(signedMessage.signature),
+            },
+          },
+          body: chunk,
+        });
+        controller.enqueue(serializedSigned);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  };
+  return new TransformStream({ ...transformer });
+};

--- a/packages/utils/src/utils.js
+++ b/packages/utils/src/utils.js
@@ -7,6 +7,7 @@ import {
   StartFaceLivenessSessionCommand,
 } from "@aws-sdk/client-rekognitionstreaming";
 
+import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler.js";
 import { REGION, IDENTITY_POOL_ID } from "./config.js";
 
 export const getV2Response = async (clientParams) => {
@@ -48,6 +49,8 @@ export const getV3BrowserResponse = async () =>
   getV3Response({
     region: REGION,
     systemClockOffset: -3600000,
+    eventStreamPayloadHandlerProvider: (options) =>
+      new EventStreamPayloadHandler(options),
     credentials: fromCognitoIdentityPool({
       client: new CognitoIdentityClient({
         region: "us-east-2",


### PR DESCRIPTION
Fix for https://github.com/aws-samples/aws-sdk-js-tests/pull/150

Verified that there is no invalid signature exception error when inspecting network tab for the StartFaceLivenessSesssion API
![Screenshot 2023-07-25 at 3 25 24 PM](https://github.com/thaddmt/aws-sdk-js-tests/assets/16024985/65df523e-73fa-409b-8bba-4d86d81d3e37)
